### PR TITLE
Explicitly support Thunderbird 60.x (fixes #9)

### DIFF
--- a/Highlighter/chrome/content/about.xul
+++ b/Highlighter/chrome/content/about.xul
@@ -7,7 +7,7 @@
   <groupbox align="center" orient="horizontal">
     <vbox>
       <text value="Highlighter" style="font-weight: bold; font-size: x-large;"/>
-      <text value="&version; 0.6.4"/>
+      <text value="&version; 0.6.6"/>
       <separator class="thin"/>
       <text value="&createdBy;" style="font-weight: bold;"/>
       <text value="André Rodier"/>

--- a/Highlighter/chrome/content/overlay.js
+++ b/Highlighter/chrome/content/overlay.js
@@ -508,7 +508,7 @@ var highlighter =
 
 // Initialise the addon on start.
 window.addEventListener("load",
-    function(e)
+    e =>
     {
         if ( !highlighter.Initialised() )
             highlighter.Initialise();
@@ -517,7 +517,7 @@ false);
 
 // Initialise the addon on start.
 window.addEventListener("unload",
-    function(e)
+    e =>
     {
         highlighter.Release();
     },

--- a/Highlighter/install.rdf
+++ b/Highlighter/install.rdf
@@ -36,7 +36,7 @@
       <Description>
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id> <!-- Thunderbird -->
         <em:minVersion>3.0</em:minVersion>
-        <em:maxVersion>5.*</em:maxVersion>
+        <em:maxVersion>60.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 

--- a/Highlighter/install.rdf
+++ b/Highlighter/install.rdf
@@ -23,7 +23,7 @@
     <em:id>andre.rodier-highlighter@gmailcom</em:id>
     <em:type>2</em:type>
     <em:name>Highlighter</em:name>
-    <em:version>0.6.4</em:version>
+    <em:version>0.6.6</em:version>
     <em:creator>André Rodier</em:creator>
     <em:contributor></em:contributor>
     <em:description>Quickly highlight some text in the thunderbird compose windows.</em:description>


### PR DESCRIPTION
This change seems to be sufficient to get this plugin working again on Thunderbird 60:

> Add-ons not marked as compatible with Thunderbird 60 by their authors will be disabled
https://www.thunderbird.net/en-US/thunderbird/60.0/releasenotes/

Thanks!